### PR TITLE
regex titles and static linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,20 @@
-CXX = g++
-CFLAGS = -O3
-OBJECTS = disorder.o md5.o
+CXXFLAGS = -O3 
+CFLAGS = $(CXXFLAGS)
+OBJECTS = wikiq.o md5.o disorder.o 
 
 all: wikiq
 
-wikiq: wikiq.cpp $(OBJECTS)
-	$(CXX) $(CFLAGS) -lpcrecpp -lexpat wikiq.cpp $(OBJECTS) -o wikiq
+wikiq: $(OBJECTS)
+	$(CXX) $(CXXFLAGS) $(OBJECTS) -lpcrecpp -lpcre -lexpat -o wikiq
 
-disorder.o: disorder.c disorder.h
-	$(CXX) $(CFLAGS) -c disorder.c
-
-md5.o: md5.c md5.h
-	$(CXX) $(CFLAGS) -c md5.c -lm
+disorder.o: disorder.h
+md5.o: md5.h
 
 clean:
 	rm -f wikiq $(OBJECTS)
+
+static: $(OBJECTS)
+	$(CXX) $(CXXFLAGS) $(OBJECTS) -static -lpcrecpp -lpcre -lexpat -o wikiq
 
 gprof:
 	$(MAKE) CFLAGS=-pg wikiq

--- a/disorder.h
+++ b/disorder.h
@@ -24,6 +24,10 @@
 #ifndef __DISORDER_H_
 #define __DISORDER_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** Max number of bytes (i.e., tokens) */
 #define LIBDO_MAX_BYTES      256
 
@@ -58,5 +62,9 @@ float    get_max_entropy(void);
 
 /** Returns the ratio of entropy to maxentropy */
 float    get_entropy_ratio(void);
+
+#ifdef __cplusplus
+};
+#endif
 
 #endif


### PR DESCRIPTION
1. Added support for regex matching of titles to (for example) match only
   things from particular namespaces. In the process, I changed the "t"
   option which prints out text to "d" for debug and used the t option for
   taking title regexes.

Keep in mind that I don't actually know C++ and please fix things up if I've done things in incorrect or inelegant ways. You wouldn't believe how long I worked on this. :)
1. Working with Bernie, I made some changes (mostly to the Makefile) so we can build a statically linked version.
